### PR TITLE
CallRecorder and stubbing methods with blocks that throw exceptions

### DIFF
--- a/lib/not_a_mock/call_recorder.rb
+++ b/lib/not_a_mock/call_recorder.rb
@@ -71,7 +71,7 @@ module NotAMock
       end
     end
 
-    def record_and_send(object, method, args)
+    def record_and_send(object, method, args)		
 	  begin    	
         result = object.send("__unlogged_#{method}", *args)
       ensure

--- a/lib/not_a_mock/call_recorder.rb
+++ b/lib/not_a_mock/call_recorder.rb
@@ -72,9 +72,13 @@ module NotAMock
     end
 
     def record_and_send(object, method, args)
-      result = object.send("__unlogged_#{method}", *args)
-      @calls << { :object => object, :method => method, :args => args, :result => result }
-      result
+	  begin    	
+        result = object.send("__unlogged_#{method}", *args)
+      ensure
+		@calls << { :object => object, :method => method, :args => args, :result => result }
+      end
+	  
+	  result
     end
   
     def remove_hook(object, method)

--- a/spec/call_recording_spec.rb
+++ b/spec/call_recording_spec.rb
@@ -61,6 +61,25 @@ describe "A recorded method" do
     @recorder.calls.should_not include(:object => @object, :method => :my_method, :args => ["argument 2"], :result => "result")
   end
   
+  it "should be recorded even when it throws an error" do
+	old_version = TrackedClass.instance_method(:my_method)
+	
+	TrackedClass.send(:define_method, :my_method) do |args|
+		raise 'ANY ERROR'
+	end
+	
+	@object = TrackedClass.new
+	@object.track_method(:my_method)
+	
+	begin
+		lambda{ @object.my_method('argument 1') }.should raise_error
+	
+		@recorder.calls_by_object(@object).size.should === 1
+	ensure
+		TrackedClass.send(:define_method, :my_method, old_version)
+	end
+  end
+  
   after do
     @recorder.reset
   end

--- a/spec/call_recording_spec.rb
+++ b/spec/call_recording_spec.rb
@@ -62,22 +62,15 @@ describe "A recorded method" do
   end
   
   it "should be recorded even when it throws an error" do
-	old_version = TrackedClass.instance_method(:my_method)
-	
-	TrackedClass.send(:define_method, :my_method) do |args|
-		raise 'ANY ERROR'
-	end
-	
-	@object = TrackedClass.new
-	@object.track_method(:my_method)
-	
-	begin
-		lambda{ @object.my_method('argument 1') }.should raise_error
-	
-		@recorder.calls_by_object(@object).size.should === 1
-	ensure
-		TrackedClass.send(:define_method, :my_method, old_version)
-	end
+    @object.untrack_method(:my_method)
+
+    def @object.my_method(arg); raise 'ANY ERROR'; end
+
+    @object.track_method(:my_method)
+
+    lambda{ @object.my_method('argument 1') }.should raise_error
+
+    @recorder.calls_by_object(@object).size.should === 1
   end
   
   after do


### PR DESCRIPTION
Hi Pete,

I ran into a situation where I needed to verify a number of method calls when one of the invocations failed. 

I wanted to ensure an object handled errors and continued in its loop.

Something like: 

```
call_count = 0
@indexer.stub_method(:index) do
    call_count += 1
    raise 'Any error' if call_count === 1
end

# ... Something that calls @indexer.index twice

# [!] Can't use this, only one has been recorded
# @indexer.must have_received(:index).twice

call_count.must === 2 
```

Does it look like a reasonable change?

<bb />
